### PR TITLE
feat: support more linux distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # scripys
+
+Docker 安装脚本，支持以下发行版：
+
+- Ubuntu
+- Debian
+- CentOS / RHEL
+- Fedora
+- openSUSE / SLES
+
+使用方法：
+
+```bash
+bash LinuxScripys/docker-install.sh
+```


### PR DESCRIPTION
## Summary
- extend docker-install.sh to handle Debian, Fedora, and openSUSE/SLES alongside Ubuntu and CentOS/RHEL
- document supported distributions in README

## Testing
- `bash -n LinuxScripys/docker-install.sh`
- `apt-get update` (fails: The repository ... InRelease is not signed)

------
https://chatgpt.com/codex/tasks/task_b_68a6f0dee5c88320aee3db6c99e263ab